### PR TITLE
Support POST for TURN

### DIFF
--- a/tailbone/turn/__init__.py
+++ b/tailbone/turn/__init__.py
@@ -108,6 +108,10 @@ class TurnHandler(BaseHandler):
       ],
     }
 
+  @as_json
+  def post(self):
+    return self.get()
+
 app = webapp2.WSGIApplication([
   (r"{}turn/?.*".format(PREFIX), TurnHandler),
 ], debug=DEBUG)


### PR DESCRIPTION
Adding POST for TURN so that Chrome App can use the turn server, since Chrome App does not set the origin header for GET requests, for does for POST requests.