### PR TITLE
Remove incorrect @as_json wrapping

### DIFF
--- a/tailbone/turn/__init__.py
+++ b/tailbone/turn/__init__.py
@@ -108,7 +108,6 @@ class TurnHandler(BaseHandler):
       ],
     }
 
-  @as_json
   def post(self):
     return self.get()
 


### PR DESCRIPTION
Removing the @as_json for TURN post which caused double wrapping of the json result.