### PR TITLE
Modify the startup script to fix a package installation error

### DIFF
--- a/tailbone/compute_engine/__init__.py
+++ b/tailbone/compute_engine/__init__.py
@@ -55,6 +55,8 @@ STATS_PORT = 8888
 
 STARTUP_SCRIPT_BASE = """#!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 # update open files limit
 ulimit -n 10000
 

--- a/tailbone/turn/__init__.py
+++ b/tailbone/turn/__init__.py
@@ -63,6 +63,13 @@ IP=$(gcutil getinstance $(hostname) 2>&1 | grep '^| *external-ip *| ' | grep -oE
 while true
 do
   turnserver --use-auth-secret -v -a -X $IP -f --static-auth-secret %s -r %s
+
+  # Sometimes the packages fail to install due to no public key error.
+  aptitude install -y debian-keyring debian-archive-keyring
+  apt-get update
+  dpkg -i rfc5766-turn-server_3.2.3.6-1_amd64.deb
+  apt-get -fy install
+
   sleep 1
 done
 


### PR DESCRIPTION
The turnserver package failed to install on the VM recently due to no public key errors (e.g. http://unix.stackexchange.com/questions/75807/no-public-key-available-on-apt-get-update).
This change modifies the startup script to handle the error and make sure packages install in unattended mode.
